### PR TITLE
1 set author on subchapters

### DIFF
--- a/src/lib/pages/abbreviation.typ
+++ b/src/lib/pages/abbreviation.typ
@@ -2,8 +2,8 @@
 #import "../global.typ" as global
 
 #let create_page() = context [
-  = Abkürzungsverzeichnis
   #global.author.update(none)
+  = Abkürzungsverzeichnis
   #for name in global.abbr.get().keys() [
     #block(breakable: false)[
       #let abbr = global.abbr.get().at(name)

--- a/src/lib/util.typ
+++ b/src/lib/util.typ
@@ -8,6 +8,9 @@
 /// Definiert man den Autor nicht, so wird der Autor des vorherigen
 /// Kapitels angenommen.
 #let author(name) = context {
+  if name != global.author.get() {
+    pagebreak(weak: true)
+  }
   global.author.update(name)
 }
 


### PR DESCRIPTION
Authors can now be set on anything, this change is possible due to states. Authors need to be declared above the heading that they should affect.

```typst
#htl3r.author("Max Mustermann")
= Chapter

#htl3r.author("Lieschen Müller")
== Subchapte
```